### PR TITLE
Use curl to download siege

### DIFF
--- a/workshop/content/300-apps/lab_14_resilient_app.adoc
+++ b/workshop/content/300-apps/lab_14_resilient_app.adoc
@@ -231,7 +231,8 @@ First you need to install the `siege` tool to your bastion VM:
 +
 [source,sh,role=execute]
 ----
-wget -o $HOME/bin/siege https://gpte-public.s3.amazonaws.com/siege
+mkdir -p $HOME/bin
+curl -o $HOME/bin/siege https://gpte-public.s3.amazonaws.com/siege
 chmod +x $HOME/bin/siege
 mkdir $HOME/.siege
 ----


### PR DESCRIPTION
The bastion host doesn't have wget and the ~/bin directory also has to be created.