### PR TITLE
create bin directory using wget -P option

### DIFF
--- a/workshop/content/300-apps/lab_14_resilient_app.adoc
+++ b/workshop/content/300-apps/lab_14_resilient_app.adoc
@@ -231,7 +231,7 @@ First you need to install the `siege` tool to your bastion VM:
 +
 [source,sh,role=execute]
 ----
-wget -o $HOME/bin/siege https://gpte-public.s3.amazonaws.com/siege
+wget -P $HOME/bin https://gpte-public.s3.amazonaws.com/siege
 chmod +x $HOME/bin/siege
 mkdir $HOME/.siege
 ----


### PR DESCRIPTION
The original wget command will attempt to retrieve the siege binary and put it in a directory that does not exist. You can use the --directory-prefix (-P) option to allow wget to create the bin directory for you