### PR TITLE
Bump version for Cluster Upgrades doc

### DIFF
--- a/workshop/content/200-ops/lab_5_cluster_upgrades.adoc
+++ b/workshop/content/200-ops/lab_5_cluster_upgrades.adoc
@@ -53,7 +53,7 @@ Channel: stable-4.12 (available channels: candidate-4.12, candidate-4.13, eus-4.
 Recommended updates:
 
   VERSION     IMAGE
-  4.13.1     quay.io/openshift-release-dev/ocp-release@sha256:db976910d909373b1136261a5479ed18ec08c93971285ff760ce75c6217d3943
+  4.13.11     quay.io/openshift-release-dev/ocp-release@sha256:e1c2377fdae1d063aaddc753b99acf25972b6997ab9a0b7e80cfef627b9ef3dd
 ----
 +
 [NOTE]
@@ -85,7 +85,7 @@ Date: 2023-04-18, Time: 19:51
 ----
 rosa upgrade cluster \
   -c rosa-${GUID} \
-  --version 4.13.1 \
+  --version 4.13.11 \
   --mode auto \
   --schedule-date ${UPGRADE_DATE} \
   --schedule-time ${UPGRADE_TIME}


### PR DESCRIPTION
Bump version for Cluster Upgrades doc. Tested in clean bookbag and it works like a charm.

```
[rosa@bastion ~]$ echo Date: ${UPGRADE_DATE}, Time: ${UPGRADE_TIME}
Date: 2023-09-13, Time: 18:37
[rosa@bastion ~]$ rosa upgrade cluster \
>   -c rosa-${GUID} \
>   --version 4.13.1 \
>   --mode auto \
>   --schedule-date ${UPGRADE_DATE} \
>   --schedule-time ${UPGRADE_TIME}
E: Expected a valid version to upgrade cluster to.
Valid versions: [4.13.11]
[rosa@bastion ~]$ rosa upgrade cluster   -c rosa-${GUID}   --version 4.13.11   --mode auto   --schedule-date ${UPGRADE_DATE}   --schedule-time ${UPGRADE_TIME}
I: Ensuring account and operator role policies for cluster '266blfgjq77iko63kbbaj16epove7aai' are compatible with upgrade.
I: Account roles/policies for cluster '266blfgjq77iko63kbbaj16epove7aai' are already up-to-date.
I: Operator roles/policies associated with the cluster '266blfgjq77iko63kbbaj16epove7aai' are already up-to-date.
I: Account and operator roles for cluster 'rosa-csl7m' are compatible with upgrade
? Are you sure you want to upgrade cluster to version '4.13.11'? Yes
I: Upgrade successfully scheduled for cluster 'rosa-csl7m'
```